### PR TITLE
Add ENVIRONMENT overrides for colors, extend with fontsize and margins

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ To get a local copy up and running follow these simple steps.
 
 You will now have a file called `$DATE ls -la.txt` with the output of ls, and a `$DATE ls -la.png` with a simulated screenshot of the terminal.
 
-### Configuratoin
+### Configuration
 
 Place a `.marauder.yml` in your home directory. 
+Optionally choose any location and set `MARAUDER_CONFIG` to point to that directory.
 
     # /home/alexander/.marauder.yml 
     #userName: alexander
@@ -141,6 +142,9 @@ Place a `.marauder.yml` in your home directory.
     outDir: /home/alexander/github.com/marauder/test
     datePrefix: false
     lineLimit: 100
+    fontSIze: 16
+    terminalMargin: 10
+    textMargin: 10
     colors:
         button1: "ff0000"
         button2: "ffff00"
@@ -153,6 +157,15 @@ Place a `.marauder.yml` in your home directory.
         dollar: "ffffff"
         command: "ff0000"
         terminal: "ffffff"
+
+It is also worth knowing that every config has a corresponding environment variable.
+
+They map such that the `userName` stanza becomes `MARAUDER_USER_NAME`. 
+You can also override colors with `MARAUDER_COLOR_*`.
+
+If you want to signal something as green, do
+
+    MARAUDER_COLOR_COMMAND="00ff00" marauder ls -la
 
 <!-- ROADMAP -->
 ## Roadmap

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -3,7 +3,6 @@ package marauder
 import (
 	"github.com/kelseyhightower/envconfig"
 	"gopkg.in/yaml.v2"
-	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -12,39 +11,45 @@ import (
 type Config struct {
 	UserName string `yaml:"userName", envconfig:"MARAUDER_USER_NAME"`
 	HostName string `yaml:"hostName", envconfig:"MARAUDER_HOST_NAME"`
-	Dir      string
 	OutDir   string `yaml:"outDir", envconfig:"MARAUDER_OUT_DIR"`
+	Dir      string
 	Colors   struct {
-		Button1    string `yaml:"button1"`
-		Button2    string `yaml:"button2"`
-		Button3    string `yaml:"button3"`
-		Background string `yaml:"background"`
-		Title      string `yaml:"title"`
-		UserName   string `yaml:"userName"`
-		At         string `yaml:"at"`
-		HostName   string `yaml:"hostName"`
-		Dollar     string `yaml:"dollar"`
-		Command    string `yaml:"command"`
-		Terminal   string `yaml:"terminal"`
+		Button1    string `yaml:"button1" envconfig:"MARAUDER_COLOR_BUTTON1"`
+		Button2    string `yaml:"button2" envconfig:"MARAUDER_COLOR_BUTTON2"`
+		Button3    string `yaml:"button3" envconfig:"MARAUDER_COLOR_BUTTON3"`
+		Background string `yaml:"background" envconfig:"MARAUDER_COLOR_BACKGROUND"`
+		Title      string `yaml:"title" envconfig:"MARAUDER_COLOR_TITLE"`
+		UserName   string `yaml:"userName" envconfig:"MARAUDER_COLOR_USERNAME"`
+		At         string `yaml:"at" envconfig:"MARAUDER_COLOR_AT"`
+		HostName   string `yaml:"hostName" envconfig:"MARAUDER_COLOR_HOSTNAME"`
+		Dollar     string `yaml:"dollar" envconfig:"MARAUDER_COLOR_DOLLAR"`
+		Command    string `yaml:"command" envconfig:"MARAUDER_COLOR_COMMAND"`
+		Terminal   string `yaml:"terminal" envconfig:"MARAUDER_COLOR_TERMINAL"`
 	} `yaml:"colors"`
-	DatePrefix bool   `yaml:"datePrefix", envconfig:"MARAUDER_DATE_PREFIX"`
-	LineLimit  uint16 `yaml:"lineLimit", envconfig:"MARAUDER_LINE_LIMIT"`
+	DatePrefix     bool    `yaml:"datePrefix", envconfig:"MARAUDER_DATE_PREFIX"`
+	LineLimit      uint16  `yaml:"lineLimit", envconfig:"MARAUDER_LINE_LIMIT"`
+	FontSize       float64 `yaml:"fontSize", envconfig:"MARAUDER_FONT_SIZE"`
+	TerminalMargin float64 `yaml:"terminalMargin", envconfig:"MARAUDER_MARGIN"`
+	TextMargin     float64 `yaml:"textMargin", envconfig:"MARAUDER_MARGIN"`
 }
 
 func (c *Config) Load() {
 	c.DatePrefix = true
 	c.LineLimit = 80
-	c.Colors.Button1 = "ff0000"
-	c.Colors.Button2 = "ffff00"
-	c.Colors.Button3 = "00ff00"
-	c.Colors.Background = "060606"
-	c.Colors.Title = "666666"
-	c.Colors.UserName = "89b482"
-	c.Colors.At = "ffffff"
-	c.Colors.HostName = "ea6962"
-	c.Colors.Dollar = "ffffff"
-	c.Colors.Command = "ff0000"
-	c.Colors.Terminal = "ffffff"
+	c.FontSize = 16.0
+	c.TerminalMargin = 10.0
+	c.TextMargin = 10.0
+	c.Colors.Button1 = "#ff0000"
+	c.Colors.Button2 = "#ffff00"
+	c.Colors.Button3 = "#00ff00"
+	c.Colors.Background = "#060606"
+	c.Colors.Title = "#666666"
+	c.Colors.UserName = "#89b482"
+	c.Colors.At = "#ffffff"
+	c.Colors.HostName = "#ea6962"
+	c.Colors.Dollar = "#ffffff"
+	c.Colors.Command = "#ff0000"
+	c.Colors.Terminal = "#ffffff"
 
 	user, err := user.Current()
 	if err != nil {
@@ -66,21 +71,18 @@ func (c *Config) Load() {
 	readEnv(c)
 }
 
-func fakeIfEnv(real string, fakeEnv string) string {
-	if fakeName := os.Getenv(fakeEnv); fakeName != "" {
-		return fakeName
-	}
-	return real
-}
 func readFile(cfg *Config) {
 	user, err := user.Current()
 	if err != nil {
 		panic(err)
 	}
 	confPath := filepath.Join(user.HomeDir, ".marauder.yml")
+	pathOverride := os.Getenv("MARAUDER_CONFIG")
+	if pathOverride != "" {
+		confPath = pathOverride
+	}
 	f, err := os.Open(confPath)
 	if err != nil {
-		log.Printf("No config found at %s", confPath)
 		return
 	}
 	defer f.Close()

--- a/pkg/console.go
+++ b/pkg/console.go
@@ -19,13 +19,12 @@ func ShellLine(userName string, hostName string, dir string) string {
 }
 
 func DrawConsole(config Config, fileName string, userName string, hostName string, dir string, outStr string) {
-	bgMargin := 10.0
-	textMargin := 10.0
+	bgMargin := math.Max(0, config.TerminalMargin)
+	textMargin := math.Max(0, config.TextMargin)
 	buttonRadius := 6.0
 	titleFontSize := 12.0
-	fontSize := 16.0
+	fontSize := config.FontSize
 	// TODO: But why?
-	adjustedFontsize := fontSize
 	lineLimit := int(math.Min(80.0, float64(config.LineLimit)))
 	// TODO: Serioiusly.. wtf is up with 0.58?????333
 	lineWidth := fontSize * float64(lineLimit) * 0.58333
@@ -39,7 +38,7 @@ func DrawConsole(config Config, fileName string, userName string, hostName strin
 	}
 
 	toolbarHeight := bgMargin + textMargin + buttonRadius
-	contextHeight := lines*int(adjustedFontsize*lineSpacing) + int(bgMargin*2) + int(textMargin*3) + int(toolbarHeight)
+	contextHeight := lines*int(fontSize*lineSpacing) + int(bgMargin*2) + int(textMargin*3) + int(toolbarHeight)
 	contextWidth := int(lineWidth) + int(bgMargin*2) + int(textMargin*2)
 
 	dc := gg.NewContext(contextWidth, contextHeight)


### PR DESCRIPTION
Also, stop `marauder` from printing out the fact it may not find a config file.